### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,8 +1,8 @@
-MT_BoardWheels	KEYWORD1	
-Init		KEYWORD2	
+MT_BoardWheels	KEYWORD1
+Init	KEYWORD2
 SetCounter	KEYWORD2
-IncrementCounter KEYWORD2
-DecrementCounter KEYWORD2
-ResetAllWheels KEYWORD2
-ResetWheel  KEYWORD2	
+IncrementCounter	KEYWORD2
+DecrementCounter	KEYWORD2
+ResetAllWheels	KEYWORD2
+ResetWheel	KEYWORD2
 DoUpdate	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords